### PR TITLE
Fixed internal system catalog chunk handling / updating

### DIFF
--- a/internal/replication/context/replicationcontext.go
+++ b/internal/replication/context/replicationcontext.go
@@ -493,6 +493,10 @@ func (rc *ReplicationContext) EnqueueTask(task Task) error {
 	return rc.dispatcher.EnqueueTask(task)
 }
 
+func (rc *ReplicationContext) RunTask(task Task) error {
+	return rc.dispatcher.RunTask(task)
+}
+
 func (rc *ReplicationContext) EnqueueTaskAndWait(task Task) error {
 	return rc.dispatcher.EnqueueTaskAndWait(task)
 }

--- a/internal/replication/logicalreplicationresolver/replicationresolver.go
+++ b/internal/replication/logicalreplicationresolver/replicationresolver.go
@@ -352,7 +352,7 @@ func (l *logicalReplicationResolver) onHypertableUpdateEvent(xld pgtypes.XLogDat
 }
 
 func (l *logicalReplicationResolver) onChunkUpdateEvent(xld pgtypes.XLogData, msg *pgtypes.UpdateMessage) error {
-	return l.replicationContext.EnqueueTask(func(notificator context.Notificator) {
+	return l.replicationContext.RunTask(func(notificator context.Notificator) {
 		notificator.NotifySystemCatalogReplicationEventHandler(
 			func(handler eventhandlers.SystemCatalogReplicationEventHandler) error {
 				return handler.OnChunkUpdatedEvent(xld, msg.RelationID, msg.OldValues, msg.NewValues)


### PR DESCRIPTION
Fixed a few issues with how chunks are handled, namely multiple added messages, delayed updates of internal catalog state, and only storing chunks required by the requested hypertables.