### PR TITLE
Extended support for decompression markers

### DIFF
--- a/internal/replication/context/replicationcontext.go
+++ b/internal/replication/context/replicationcontext.go
@@ -396,8 +396,8 @@ func (rc *ReplicationContext) IsMinimumTimescaleVersion() bool {
 	return rc.tsdbVersion >= intversion.TSDB_MIN_VERSION
 }
 
-func (rc *ReplicationContext) IsTSDB211GE() bool {
-	return rc.tsdbVersion >= intversion.TSDB_211_VERSION
+func (rc *ReplicationContext) IsTSDB212GE() bool {
+	return rc.tsdbVersion >= intversion.TSDB_212_VERSION
 }
 
 func (rc *ReplicationContext) IsLogicalReplicationEnabled() bool {

--- a/internal/replication/logicalreplicationresolver/factory.go
+++ b/internal/replication/logicalreplicationresolver/factory.go
@@ -27,7 +27,7 @@ func NewResolver(config *spiconfig.Config, replicationContext *context.Replicati
 	}
 
 	if enabled && maxSize > 0 {
-		return newTransactionTracker(timeout, maxSize, systemCatalog, resolver)
+		return newTransactionTracker(timeout, maxSize, replicationContext, systemCatalog, resolver)
 	}
 	return resolver, nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,7 +4,7 @@ import "github.com/noctarius/timescaledb-event-streamer/spi/version"
 
 const (
 	TSDB_MIN_VERSION version.TimescaleVersion = 21000
-	TSDB_211_VERSION version.TimescaleVersion = 21100
+	TSDB_212_VERSION version.TimescaleVersion = 21200
 	PG_MIN_VERSION   version.PostgresVersion  = 130000
 	PG_14_VERSION    version.PostgresVersion  = 140000
 )


### PR DESCRIPTION
Added extended support for decompression markers sent as logical replication messages