### PR TITLE
Extended workflow with <2.12 and >=2.12 TSDB builds

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,8 +54,9 @@ jobs:
       fail-fast: false
       matrix:
         pg_version: [13, 14, 15]
+        tsdb_version: ["2.11", "latest"]
 
-    name: Tests (Unit / PG) - PG ${{ matrix.pg_version }}
+    name: Tests (Unit / PG) - PG ${{ matrix.pg_version }} / TSDB ${{ matrix.tsdb_version }}
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
@@ -69,7 +70,7 @@ jobs:
       id: go
 
     - name: Test
-      run: TSES_TEST_PG_VERSION=${{ matrix.pg_version }} make test
+      run: TSES_TEST_PG_VERSION=${{ matrix.pg_version }} TSES_TEST_TSDB_VERSION=${{ matrix.tsdb_version }} make test
 
   integration-test:
     strategy:

--- a/testsupport/containers/timescaledb.go
+++ b/testsupport/containers/timescaledb.go
@@ -91,9 +91,21 @@ func SetupTimescaleContainer() (testcontainers.Container, *ConfigProvider, error
 		}
 		pgVersion = int(v)
 	}
+	tsdbVersion := "latest"
+	val, present = os.LookupEnv("TSES_TEST_TSDB_VERSION")
+	if present {
+		if val != "latest" {
+			tsdbVersion = val
+		}
+	}
+
+	imageName := fmt.Sprintf("timescale/timescaledb-ha:pg%d-ts%s-all", pgVersion, tsdbVersion)
+	if tsdbVersion == "latest" {
+		imageName = fmt.Sprintf("timescale/timescaledb-ha:pg%d-all", pgVersion)
+	}
 
 	containerRequest := testcontainers.ContainerRequest{
-		Image:        fmt.Sprintf("timescale/timescaledb-ha:pg%d-all", pgVersion),
+		Image:        imageName,
 		ExposedPorts: []string{"5432/tcp"},
 		Cmd:          []string{"-c", "fsync=off", "-c", "wal_level=logical"},
 		WaitingFor: wait.ForAll(


### PR DESCRIPTION
Added a forced pre-2.12 build and a latest build to capture both 2.12+ versions with support for decompression markers and <2.12 builds with transaction collectors