### PR TITLE
NATS core support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ NATS specific configuration, which is only used if `sink.type` is set to `nats`.
 | `sink.nats.userinfo.password`       |                                  The password of userinfo authorization details. |           string |  empty string | 
 | `sink.nats.credentials.certificate` |           The path of the certificate file of credentials authorization details. |           string |  empty string | 
 | `sink.nats.credentials.seeds`       |                 The paths of seeding files of credentials authorization details. | array of strings |   empty array | 
+| `sink.nats.mode`                    |               The type of NATS clinent mode (core/jetstream) to publish message. |           string |     jetstream |
+| `sink.nats.timeouts.publishtimeout` |                                                  The timeout to publish message. |              int |             2 |
+| `sink.nats.timeouts.dialtimeout`    |                                            The timeout for Dial on a connection. |              int |             2 |
+| `sink.nats.timeouts.reconnectwait`  |                                        The wait time between reconnect attempts. |              int |             2 |
 
 ### Kafka Sink Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pglogrepl v0.0.0-20230810221841-d0818e1fbef7
 	github.com/jackc/pgx/v5 v5.4.3
-	github.com/nats-io/nats.go v1.30.2
+	github.com/nats-io/nats.go v1.31.0
 	github.com/samber/do v1.6.0
 	github.com/samber/lo v1.38.1
 	github.com/segmentio/stats/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/nats-io/nats-server/v2 v2.9.15 h1:MuwEJheIwpvFgqvbs20W8Ish2azcygjf4Z0
 github.com/nats-io/nats-server/v2 v2.9.15/go.mod h1:QlCTy115fqpx4KSOPFIxSV7DdI6OxtZsGOL1JLdeRlE=
 github.com/nats-io/nats.go v1.30.2 h1:aloM0TGpPorZKQhbAkdCzYDj+ZmsJDyeo3Gkbr72NuY=
 github.com/nats-io/nats.go v1.30.2/go.mod h1:dcfhUgmQNN4GJEfIb2f9R7Fow+gzBF4emzDHrVBd5qM=
+github.com/nats-io/nats.go v1.31.0 h1:/WFBHEc/dOKBF6qf1TZhrdEfTmOZ5JzdJ+Y3m6Y/p7E=
+github.com/nats-io/nats.go v1.31.0/go.mod h1:di3Bm5MLsoB4Bx61CBTsxuarI36WbhAwOm8QrW39+i8=
 github.com/nats-io/nkeys v0.4.5 h1:Zdz2BUlFm4fJlierwvGK+yl20IAKUm7eV6AAZXEhkPk=
 github.com/nats-io/nkeys v0.4.5/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/spi/config/configuration.go
+++ b/spi/config/configuration.go
@@ -19,10 +19,11 @@ package config
 
 import (
 	"crypto/tls"
-	"github.com/IBM/sarama"
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/IBM/sarama"
 )
 
 type StateStorageType string
@@ -180,6 +181,14 @@ type NatsConfig struct {
 	UserInfo      NatsUserInfoConfig    `toml:"userinfo" yaml:"userInfo"`
 	Credentials   NatsCredentialsConfig `toml:"credentials" yaml:"credentials"`
 	JWT           NatsJWTConfig         `toml:"jwt" yaml:"jwt"`
+	Mode          string                `toml:"mode" yaml:"mode"`
+	Timeout       NatsTimeoutConfig     `toml:"timeouts" yaml:"timeouts"`
+}
+
+type NatsTimeoutConfig struct {
+	ReconnectWait  int `toml:"reconnectwait" yaml:"reconnectwait"`
+	DialTimeout    int `toml:"dialtimeout" yaml:"dialtimeout"`
+	PublishTimeout int `toml:"publishtimeout" yaml:"publishtimeout"`
 }
 
 type KafkaSaslConfig struct {

--- a/spi/config/constants.go
+++ b/spi/config/constants.go
@@ -80,6 +80,10 @@ const (
 	PropertyNatsCredentialsSeeds       = "sink.nats.credentials.seeds"
 	PropertyNatsJwt                    = "sink.nats.jwt.jwt"
 	PropertyNatsJwtSeed                = "sink.nats.jwt.seed"
+	PropertyNatsMode                   = "sink.nats.mode"
+	PropertyNatsTimeoutDialTimeout     = "sink.nats.timeouts.dialtimeout"
+	PropertyNatsTimeoutReconnectWait   = "sink.nats.timeouts.reconnectwait"
+	PropertyNatsTimeoutPublishTimeout  = "sink.nats.timeouts.publishtimeout"
 
 	PropertyRedisNetwork           = "sink.redis.network"
 	PropertyRedisAddress           = "sink.redis.address"


### PR DESCRIPTION
- Bump github.com/nats-io/nats.go v1.30.2 to 1.31.0
- NATS sink: added support core nats messaging in addition to jetstream
- NATS sink: added timeouts configuration options.  publishtimeout, dialtimeout, reconnecttimeout
