### PR TITLE
Remove `distributed` field from hypertable, adds support for timescale post 2.13

### DIFF
--- a/internal/sidechannel/queries.go
+++ b/internal/sidechannel/queries.go
@@ -73,7 +73,7 @@ const queryCreatePublication = "SELECT create_timescaledb_catalog_publication($1
 
 const queryTemplateDropPublication = "DROP PUBLICATION IF EXISTS %s"
 
-const queryCheckPublicationExists = "SELECT TRUE FROM pg_publication WHERE pubname = $1"
+const queryCheckPublicationExists = "SELECT true FROM pg_publication WHERE pubname = $1"
 
 const queryReadExistingAlreadyPublishedTables = `
 SELECT pt.schemaname, pt.tablename
@@ -81,7 +81,7 @@ FROM pg_catalog.pg_publication_tables pt
 WHERE pt.pubname = $1`
 
 const queryCheckTableExistsInPublication = `
-SELECT TRUE
+SELECT true
 FROM pg_catalog.pg_publication_tables pt
 WHERE pt.pubname = $1
   AND pt.schemaname = $2
@@ -96,7 +96,7 @@ FROM pg_catalog.pg_replication_slots prs
 WHERE slot_name = $1`
 
 const queryCheckReplicationSlotExists = `
-SELECT TRUE
+SELECT true
 FROM pg_catalog.pg_replication_slots prs
 WHERE slot_name = $1`
 
@@ -125,27 +125,27 @@ FROM _timescaledb_catalog.chunk c1
 LEFT JOIN timescaledb_information.chunks c2
        ON c2.chunk_schema = c1.schema_name
       AND c2.chunk_name = c1.table_name
-ORDER BY c1.hypertable_id, c1.compressed_chunk_id NULLS FIRST, c2.range_start`
+ORDER BY c1.hypertable_id, c1.compressed_chunk_id nulls first, c2.range_start`
 
 const queryReadHypertableSchema = `
 SELECT
    c.column_name,
    t.oid::int,
    a.atttypmod,
-   CASE WHEN c.is_nullable = 'YES' THEN TRUE ELSE FALSE END AS nullable,
-   COALESCE(p.indisprimary, FALSE) AS is_primary_key,
+   CASE WHEN c.is_nullable = 'YES' THEN true ELSE false END AS nullable,
+   coalesce(p.indisprimary, false) AS is_primary_key,
    p.key_seq,
    c.column_default,
-   COALESCE(p.indisreplident, FALSE) AS is_replica_ident,
+   coalesce(p.indisreplident, false) AS is_replica_ident,
    p.index_name,
    CASE o.option & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END AS index_column_order,
    CASE o.option & 2 WHEN 2 THEN 'NULLS FIRST' ELSE 'NULLS LAST' END AS index_nulls_order,
    d.column_name IS NOT NULL AS is_dimension,
-   COALESCE(d.aligned, FALSE) AS dim_aligned,
+   coalesce(d.aligned, false) AS dim_aligned,
    CASE WHEN d.interval_length IS NULL THEN 'space' ELSE 'time' END AS dim_type,
-   CASE WHEN d.column_name IS NOT NULL THEN rank() over (ORDER BY d.id) END,
-   C.character_maximum_length
-FROM information_schema.columns C
+   CASE WHEN d.column_name IS NOT NULL THEN rank() over (order by d.id) END,
+   c.character_maximum_length
+FROM information_schema.columns c
 LEFT JOIN (
     SELECT
         cl.relname,
@@ -164,18 +164,18 @@ LEFT JOIN (
       AND i.indrelid = cl.oid
       AND i.indexrelid = cl2.oid
       AND i.indisprimary
-) p ON p.attname = C.column_name AND p.nspname = C.table_schema AND p.relname = C.table_name AND p.attnum = (p.keys).x
-LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = C.udt_schema
-LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = C.udt_name
-LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = C.table_schema
-LEFT JOIN pg_catalog.pg_class cl ON cl.relname = C.table_name AND cl.relnamespace = nc.oid
-LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = C.ordinal_position
-LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (OPTION, ORDINALITY) ON p.attnum = o.ordinality
-LEFT JOIN _timescaledb_catalog.hypertable h ON h.schema_name = C.table_schema AND h.table_name = C.table_name
-LEFT JOIN _timescaledb_catalog.dimension d ON d.hypertable_id = h.id AND d.column_name = C.column_name
-WHERE C.table_schema = $1
-  AND C.table_name = $2
-ORDER BY C.ordinal_position`
+) p ON p.attname = c.column_name AND p.nspname = c.table_schema AND p.relname = c.table_name AND p.attnum = (p.keys).x
+LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = c.udt_schema
+LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = c.udt_name
+LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = c.table_schema
+LEFT JOIN pg_catalog.pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = nc.oid
+LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = c.ordinal_position
+LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (option, ordinality) ON p.attnum = o.ordinality
+LEFT JOIN _timescaledb_catalog.hypertable h ON h.schema_name = c.table_schema AND h.table_name = c.table_name
+LEFT JOIN _timescaledb_catalog.dimension d ON d.hypertable_id = h.id AND d.column_name = c.column_name
+WHERE c.table_schema = $1
+  AND c.table_name = $2
+ORDER BY c.ordinal_position`
 
 const queryReadContinuousAggregateInformation = `
 SELECT ca.user_view_schema, ca.user_view_name
@@ -189,7 +189,7 @@ const queryReadReplicaIdentity = `
 SELECT c.relreplident::text
 FROM pg_catalog.pg_class c
 LEFT JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-WHERE n.nspname=$1 AND c.relname=$2`
+WHERE n.nspname=$1 and c.relname=$2`
 
 const queryTemplateSnapshotHighWatermark = `
 SELECT %s
@@ -205,7 +205,7 @@ SELECT a.attname,
        a.atttypmod,
        a.attnotnull
 FROM pg_catalog.pg_attribute a
-RIGHT JOIN pg_catalog.pg_class pc ON pc.reltype = $1
+RIGHT JOIN pg_catalog.pg_class pc on pc.reltype = $1
 WHERE a.attrelid = pc.oid AND a.attnum > 0 AND NOT a.attisdropped
 ORDER BY a.attnum`
 
@@ -226,16 +226,16 @@ SELECT
    c.column_name,
    t.oid::int,
    a.atttypmod,
-   CASE WHEN c.is_nullable = 'YES' THEN TRUE ELSE FALSE END AS nullable,
-   COALESCE(p.indisprimary, FALSE) AS is_primary_key,
+   CASE WHEN c.is_nullable = 'YES' THEN true ELSE false END AS nullable,
+   coalesce(p.indisprimary, false) AS is_primary_key,
    p.key_seq,
    c.column_default,
-   COALESCE(p.indisreplident, FALSE) AS is_replica_ident,
+   coalesce(p.indisreplident, false) AS is_replica_ident,
    p.index_name,
    CASE o.option & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END AS index_column_order,
    CASE o.option & 2 WHEN 2 THEN 'NULLS FIRST' ELSE 'NULLS LAST' END AS index_nulls_order,
-   C.character_maximum_length
-FROM information_schema.columns C
+   c.character_maximum_length
+FROM information_schema.columns c
 LEFT JOIN (
     SELECT
         cl.relname,
@@ -254,15 +254,15 @@ LEFT JOIN (
       AND i.indrelid = cl.oid
       AND i.indexrelid = cl2.oid
       AND i.indisprimary
-) p ON p.attname = C.column_name AND p.nspname = C.table_schema AND p.relname = C.table_name AND p.attnum = (p.keys).x
-LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = C.udt_schema
-LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = C.udt_name
-LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = C.table_schema
-LEFT JOIN pg_catalog.pg_class cl ON cl.relname = C.table_name AND cl.relnamespace = nc.oid
-LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = C.ordinal_position
-LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (OPTION, ORDINALITY) ON p.attnum = o.ordinality
-WHERE C.table_schema = $1
-  AND C.table_name = $2
-ORDER BY C.ordinal_position`
+) p ON p.attname = c.column_name AND p.nspname = c.table_schema AND p.relname = c.table_name AND p.attnum = (p.keys).x
+LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = c.udt_schema
+LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = c.udt_name
+LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = c.table_schema
+LEFT JOIN pg_catalog.pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = nc.oid
+LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = c.ordinal_position
+LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (option, ordinality) ON p.attnum = o.ordinality
+WHERE c.table_schema = $1
+  AND c.table_name = $2
+ORDER BY c.ordinal_position`
 
 // endregion

--- a/internal/sidechannel/queries.go
+++ b/internal/sidechannel/queries.go
@@ -73,7 +73,7 @@ const queryCreatePublication = "SELECT create_timescaledb_catalog_publication($1
 
 const queryTemplateDropPublication = "DROP PUBLICATION IF EXISTS %s"
 
-const queryCheckPublicationExists = "SELECT true FROM pg_publication WHERE pubname = $1"
+const queryCheckPublicationExists = "SELECT TRUE FROM pg_publication WHERE pubname = $1"
 
 const queryReadExistingAlreadyPublishedTables = `
 SELECT pt.schemaname, pt.tablename
@@ -81,7 +81,7 @@ FROM pg_catalog.pg_publication_tables pt
 WHERE pt.pubname = $1`
 
 const queryCheckTableExistsInPublication = `
-SELECT true
+SELECT TRUE
 FROM pg_catalog.pg_publication_tables pt
 WHERE pt.pubname = $1
   AND pt.schemaname = $2
@@ -96,7 +96,7 @@ FROM pg_catalog.pg_replication_slots prs
 WHERE slot_name = $1`
 
 const queryCheckReplicationSlotExists = `
-SELECT true
+SELECT TRUE
 FROM pg_catalog.pg_replication_slots prs
 WHERE slot_name = $1`
 
@@ -105,8 +105,7 @@ WHERE slot_name = $1`
 // region Hypertable / Chunk Related Queries
 const queryReadHypertables = `
 SELECT h1.id, h1.schema_name, h1.table_name, h1.associated_schema_name, h1.associated_table_prefix,
-	 h1.compression_state, h1.compressed_hypertable_id, coalesce(h2.is_distributed, false),
-	 ca.user_view_schema, ca.user_view_name, c.relreplident
+	 h1.compression_state, h1.compressed_hypertable_id, ca.user_view_schema, ca.user_view_name, c.relreplident
 FROM _timescaledb_catalog.hypertable h1
 LEFT JOIN timescaledb_information.hypertables h2
 	 ON h2.hypertable_schema = h1.schema_name
@@ -126,27 +125,27 @@ FROM _timescaledb_catalog.chunk c1
 LEFT JOIN timescaledb_information.chunks c2
        ON c2.chunk_schema = c1.schema_name
       AND c2.chunk_name = c1.table_name
-ORDER BY c1.hypertable_id, c1.compressed_chunk_id nulls first, c2.range_start`
+ORDER BY c1.hypertable_id, c1.compressed_chunk_id NULLS FIRST, c2.range_start`
 
 const queryReadHypertableSchema = `
 SELECT
    c.column_name,
    t.oid::int,
    a.atttypmod,
-   CASE WHEN c.is_nullable = 'YES' THEN true ELSE false END AS nullable,
-   coalesce(p.indisprimary, false) AS is_primary_key,
+   CASE WHEN c.is_nullable = 'YES' THEN TRUE ELSE FALSE END AS nullable,
+   COALESCE(p.indisprimary, FALSE) AS is_primary_key,
    p.key_seq,
    c.column_default,
-   coalesce(p.indisreplident, false) AS is_replica_ident,
+   COALESCE(p.indisreplident, FALSE) AS is_replica_ident,
    p.index_name,
    CASE o.option & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END AS index_column_order,
    CASE o.option & 2 WHEN 2 THEN 'NULLS FIRST' ELSE 'NULLS LAST' END AS index_nulls_order,
    d.column_name IS NOT NULL AS is_dimension,
-   coalesce(d.aligned, false) AS dim_aligned,
+   COALESCE(d.aligned, FALSE) AS dim_aligned,
    CASE WHEN d.interval_length IS NULL THEN 'space' ELSE 'time' END AS dim_type,
-   CASE WHEN d.column_name IS NOT NULL THEN rank() over (order by d.id) END,
-   c.character_maximum_length
-FROM information_schema.columns c
+   CASE WHEN d.column_name IS NOT NULL THEN rank() over (ORDER BY d.id) END,
+   C.character_maximum_length
+FROM information_schema.columns C
 LEFT JOIN (
     SELECT
         cl.relname,
@@ -165,18 +164,18 @@ LEFT JOIN (
       AND i.indrelid = cl.oid
       AND i.indexrelid = cl2.oid
       AND i.indisprimary
-) p ON p.attname = c.column_name AND p.nspname = c.table_schema AND p.relname = c.table_name AND p.attnum = (p.keys).x
-LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = c.udt_schema
-LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = c.udt_name
-LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = c.table_schema
-LEFT JOIN pg_catalog.pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = nc.oid
-LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = c.ordinal_position
-LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (option, ordinality) ON p.attnum = o.ordinality
-LEFT JOIN _timescaledb_catalog.hypertable h ON h.schema_name = c.table_schema AND h.table_name = c.table_name
-LEFT JOIN _timescaledb_catalog.dimension d ON d.hypertable_id = h.id AND d.column_name = c.column_name
-WHERE c.table_schema = $1
-  AND c.table_name = $2
-ORDER BY c.ordinal_position`
+) p ON p.attname = C.column_name AND p.nspname = C.table_schema AND p.relname = C.table_name AND p.attnum = (p.keys).x
+LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = C.udt_schema
+LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = C.udt_name
+LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = C.table_schema
+LEFT JOIN pg_catalog.pg_class cl ON cl.relname = C.table_name AND cl.relnamespace = nc.oid
+LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = C.ordinal_position
+LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (OPTION, ORDINALITY) ON p.attnum = o.ordinality
+LEFT JOIN _timescaledb_catalog.hypertable h ON h.schema_name = C.table_schema AND h.table_name = C.table_name
+LEFT JOIN _timescaledb_catalog.dimension d ON d.hypertable_id = h.id AND d.column_name = C.column_name
+WHERE C.table_schema = $1
+  AND C.table_name = $2
+ORDER BY C.ordinal_position`
 
 const queryReadContinuousAggregateInformation = `
 SELECT ca.user_view_schema, ca.user_view_name
@@ -190,7 +189,7 @@ const queryReadReplicaIdentity = `
 SELECT c.relreplident::text
 FROM pg_catalog.pg_class c
 LEFT JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-WHERE n.nspname=$1 and c.relname=$2`
+WHERE n.nspname=$1 AND c.relname=$2`
 
 const queryTemplateSnapshotHighWatermark = `
 SELECT %s
@@ -206,7 +205,7 @@ SELECT a.attname,
        a.atttypmod,
        a.attnotnull
 FROM pg_catalog.pg_attribute a
-RIGHT JOIN pg_catalog.pg_class pc on pc.reltype = $1
+RIGHT JOIN pg_catalog.pg_class pc ON pc.reltype = $1
 WHERE a.attrelid = pc.oid AND a.attnum > 0 AND NOT a.attisdropped
 ORDER BY a.attnum`
 
@@ -227,16 +226,16 @@ SELECT
    c.column_name,
    t.oid::int,
    a.atttypmod,
-   CASE WHEN c.is_nullable = 'YES' THEN true ELSE false END AS nullable,
-   coalesce(p.indisprimary, false) AS is_primary_key,
+   CASE WHEN c.is_nullable = 'YES' THEN TRUE ELSE FALSE END AS nullable,
+   COALESCE(p.indisprimary, FALSE) AS is_primary_key,
    p.key_seq,
    c.column_default,
-   coalesce(p.indisreplident, false) AS is_replica_ident,
+   COALESCE(p.indisreplident, FALSE) AS is_replica_ident,
    p.index_name,
    CASE o.option & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END AS index_column_order,
    CASE o.option & 2 WHEN 2 THEN 'NULLS FIRST' ELSE 'NULLS LAST' END AS index_nulls_order,
-   c.character_maximum_length
-FROM information_schema.columns c
+   C.character_maximum_length
+FROM information_schema.columns C
 LEFT JOIN (
     SELECT
         cl.relname,
@@ -255,15 +254,15 @@ LEFT JOIN (
       AND i.indrelid = cl.oid
       AND i.indexrelid = cl2.oid
       AND i.indisprimary
-) p ON p.attname = c.column_name AND p.nspname = c.table_schema AND p.relname = c.table_name AND p.attnum = (p.keys).x
-LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = c.udt_schema
-LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = c.udt_name
-LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = c.table_schema
-LEFT JOIN pg_catalog.pg_class cl ON cl.relname = c.table_name AND cl.relnamespace = nc.oid
-LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = c.ordinal_position
-LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (option, ordinality) ON p.attnum = o.ordinality
-WHERE c.table_schema = $1
-  AND c.table_name = $2
-ORDER BY c.ordinal_position`
+) p ON p.attname = C.column_name AND p.nspname = C.table_schema AND p.relname = C.table_name AND p.attnum = (p.keys).x
+LEFT JOIN pg_catalog.pg_namespace nt ON nt.nspname = C.udt_schema
+LEFT JOIN pg_catalog.pg_type t ON t.typnamespace = nt.oid AND t.typname = C.udt_name
+LEFT JOIN pg_catalog.pg_namespace nc ON nc.nspname = C.table_schema
+LEFT JOIN pg_catalog.pg_class cl ON cl.relname = C.table_name AND cl.relnamespace = nc.oid
+LEFT JOIN pg_catalog.pg_attribute a ON a.attrelid = cl.oid AND a.attnum = C.ordinal_position
+LEFT JOIN unnest (p.indoption) WITH ORDINALITY o (OPTION, ORDINALITY) ON p.attnum = o.ordinality
+WHERE C.table_schema = $1
+  AND C.table_name = $2
+ORDER BY C.ordinal_position`
 
 // endregion

--- a/internal/sidechannel/sidechannel.go
+++ b/internal/sidechannel/sidechannel.go
@@ -255,20 +255,19 @@ func (sc *sideChannel) ReadHypertables(
 			var schemaName, hypertableName, associatedSchemaName, associatedTablePrefix string
 			var compressionState int16
 			var compressedHypertableId *int32
-			var distributed bool
 			var viewSchema, viewName *string
 			var replicaIdentity pgtypes.ReplicaIdentity
 
 			if err := row.Scan(&id, &schemaName, &hypertableName, &associatedSchemaName,
 				&associatedTablePrefix, &compressionState, &compressedHypertableId,
-				&distributed, &viewSchema, &viewName, &replicaIdentity); err != nil {
+				&viewSchema, &viewName, &replicaIdentity); err != nil {
 
 				return errors.Wrap(err, 0)
 			}
 
 			hypertable := systemcatalog.NewHypertable(
 				id, schemaName, hypertableName, associatedSchemaName, associatedTablePrefix,
-				compressedHypertableId, compressionState, distributed, viewSchema, viewName, replicaIdentity,
+				compressedHypertableId, compressionState, viewSchema, viewName, replicaIdentity,
 			)
 
 			return cb(hypertable)

--- a/internal/systemcatalog/catalogeventhandler.go
+++ b/internal/systemcatalog/catalogeventhandler.go
@@ -26,7 +26,7 @@ import (
 
 type hypertableDecomposerCallback = func(
 	id int32, schemaName, hypertableName, associatedSchemaName, associatedTablePrefix string,
-	compressedHypertableId *int32, compressionState int16, distributed bool,
+	compressedHypertableId *int32, compressionState int16,
 ) error
 
 type chunkDecomposerCallback = func(id, hypertableId int32, schemaName,
@@ -61,7 +61,7 @@ func (s *systemCatalogReplicationEventHandler) OnHypertableAddedEvent(
 
 	return s.decomposeHypertable(newValues,
 		func(id int32, schemaName, hypertableName, associatedSchemaName, associatedTablePrefix string,
-			compressedHypertableId *int32, compressionState int16, distributed bool) error {
+			compressedHypertableId *int32, compressionState int16) error {
 
 			var viewSchema, viewName *string
 			if systemcatalog.IsContinuousAggregateHypertable(hypertableName) {
@@ -80,7 +80,7 @@ func (s *systemCatalogReplicationEventHandler) OnHypertableAddedEvent(
 
 			h := systemcatalog.NewHypertable(
 				id, schemaName, hypertableName, associatedSchemaName, associatedTablePrefix,
-				compressedHypertableId, compressionState, distributed, viewSchema, viewName, replicaIdentity,
+				compressedHypertableId, compressionState, viewSchema, viewName, replicaIdentity,
 			)
 
 			if err := s.systemCatalog.RegisterHypertable(h); err != nil {
@@ -101,7 +101,7 @@ func (s *systemCatalogReplicationEventHandler) OnHypertableUpdatedEvent(
 
 	return s.decomposeHypertable(newValues,
 		func(id int32, schemaName, hypertableName, associatedSchemaName, associatedTablePrefix string,
-			compressedHypertableId *int32, compressionState int16, distributed bool) error {
+			compressedHypertableId *int32, compressionState int16) error {
 
 			if hypertable, present := s.systemCatalog.FindHypertableById(id); present {
 				replicaIdentity, err := s.systemCatalog.sideChannel.ReadReplicaIdentity(
@@ -251,16 +251,12 @@ func (s *systemCatalogReplicationEventHandler) decomposeHypertable(
 	associatedSchemaName := values["associated_schema_name"].(string)
 	associatedTablePrefix := values["associated_table_prefix"].(string)
 	compressionState := values["compression_state"].(int16)
-	var distributed bool
-	if v, ok := values["replication_factor"].(int16); ok {
-		distributed = v > 0
-	}
 	var compressedHypertableId *int32
 	if v, ok := values["compressed_hypertable_id"].(int32); ok {
 		compressedHypertableId = &v
 	}
 	return cb(id, schemaName, hypertableName, associatedSchemaName, associatedTablePrefix,
-		compressedHypertableId, compressionState, distributed,
+		compressedHypertableId, compressionState,
 	)
 }
 

--- a/internal/systemcatalog/tablefiltering/tablefilter_test.go
+++ b/internal/systemcatalog/tablefiltering/tablefilter_test.go
@@ -442,7 +442,6 @@ func makeHypertable(
 		"test",
 		nil,
 		0,
-		false,
 		nil,
 		nil,
 		pgtypes.DEFAULT,

--- a/spi/systemcatalog/hypertable.go
+++ b/spi/systemcatalog/hypertable.go
@@ -33,7 +33,6 @@ type Hypertable struct {
 	associatedTablePrefix  string
 	compressedHypertableId *int32
 	compressionState       int16
-	distributed            bool
 	continuousAggregate    bool
 	viewSchema             *string
 	viewName               *string
@@ -42,7 +41,7 @@ type Hypertable struct {
 // NewHypertable instantiates a new Hypertable entity
 func NewHypertable(
 	id int32, schemaName, tableName, associatedSchemaName, associatedTablePrefix string,
-	compressedHypertableId *int32, compressionState int16, distributed bool,
+	compressedHypertableId *int32, compressionState int16,
 	viewSchema, viewName *string, replicaIdentity pgtypes.ReplicaIdentity,
 ) *Hypertable {
 
@@ -53,7 +52,6 @@ func NewHypertable(
 		associatedTablePrefix:  associatedTablePrefix,
 		compressedHypertableId: compressedHypertableId,
 		compressionState:       compressionState,
-		distributed:            distributed,
 		continuousAggregate:    isContinuousAggregate(tableName, viewSchema, viewName),
 		viewSchema:             viewSchema,
 		viewName:               viewName,
@@ -109,14 +107,8 @@ func (h *Hypertable) IsCompressedTable() bool {
 	return h.compressionState == 2
 }
 
-// IsDistributed returns true if the hypertable is a
-// distributed hypertable, otherwise false
-func (h *Hypertable) IsDistributed() bool {
-	return h.distributed
-}
-
 // IsContinuousAggregate returns true if the hypertable
-// is a backing hypertable for a continues aggregate,
+// is a backing hypertable for a continuous aggregate,
 // otherwise false
 func (h *Hypertable) IsContinuousAggregate() bool {
 	return h.continuousAggregate
@@ -200,7 +192,6 @@ func (h *Hypertable) ApplyChanges(
 		associatedTablePrefix:  associatedTablePrefix,
 		compressedHypertableId: compressedHypertableId,
 		compressionState:       compressionState,
-		distributed:            h.distributed,
 	}
 	return h2, h.differences(h2)
 }

--- a/spi/systemcatalog/hypertable_test.go
+++ b/spi/systemcatalog/hypertable_test.go
@@ -41,7 +41,7 @@ func TestSchemaDifferences_Added_Column(
 		NewColumn("test3", 10, -1, fooType, false, nil),
 		NewColumn("test4", 10, -1, fooType, false, nil),
 	}
-	hypertable := NewHypertable(1, "", "", "", "", nil, 0, false, nil, nil, pgtypes.DEFAULT)
+	hypertable := NewHypertable(1, "", "", "", "", nil, 0, nil, nil, pgtypes.DEFAULT)
 	hypertable.ApplyTableSchema(oldColumns)
 	differences := hypertable.ApplyTableSchema(newColumns)
 
@@ -73,7 +73,7 @@ func TestSchemaDifferences_Renamed_Column(
 		NewColumn("test4", 10, -1, fooType, false, nil),
 		NewColumn("test3", 10, -1, fooType, false, nil),
 	}
-	hypertable := NewHypertable(1, "", "", "", "", nil, 0, false, nil, nil, pgtypes.DEFAULT)
+	hypertable := NewHypertable(1, "", "", "", "", nil, 0, nil, nil, pgtypes.DEFAULT)
 	hypertable.ApplyTableSchema(oldColumns)
 	differences := hypertable.ApplyTableSchema(newColumns)
 
@@ -105,7 +105,7 @@ func TestSchemaDifferences_Renamed_Last_Column(
 		NewColumn("test2", 10, -1, fooType, false, nil),
 		NewColumn("test4", 10, -1, fooType, false, nil),
 	}
-	hypertable := NewHypertable(1, "", "", "", "", nil, 0, false, nil, nil, pgtypes.DEFAULT)
+	hypertable := NewHypertable(1, "", "", "", "", nil, 0, nil, nil, pgtypes.DEFAULT)
 	hypertable.ApplyTableSchema(oldColumns)
 	differences := hypertable.ApplyTableSchema(newColumns)
 
@@ -136,7 +136,7 @@ func TestSchemaDifferences_Dropped_Column(
 		NewColumn("test1", 10, -1, fooType, false, nil),
 		NewColumn("test3", 12, -1, fooType, false, nil),
 	}
-	hypertable := NewHypertable(1, "", "", "", "", nil, 0, false, nil, nil, pgtypes.DEFAULT)
+	hypertable := NewHypertable(1, "", "", "", "", nil, 0, nil, nil, pgtypes.DEFAULT)
 	hypertable.ApplyTableSchema(oldColumns)
 	differences := hypertable.ApplyTableSchema(newColumns)
 
@@ -167,7 +167,7 @@ func TestSchemaDifferences_Dropped_Last_Column(
 		NewColumn("test1", 10, -1, fooType, false, nil),
 		NewColumn("test2", 10, -1, fooType, false, nil),
 	}
-	hypertable := NewHypertable(1, "", "", "", "", nil, 0, false, nil, nil, pgtypes.DEFAULT)
+	hypertable := NewHypertable(1, "", "", "", "", nil, 0, nil, nil, pgtypes.DEFAULT)
 	hypertable.ApplyTableSchema(oldColumns)
 	differences := hypertable.ApplyTableSchema(newColumns)
 


### PR DESCRIPTION
Timescale 2.14 removes multi-node support see [this](https://docs.timescale.com/self-hosted/latest/multinode-timescaledb/multinode-setup/), with it also removes some fields related to it. One of them is `is_distributed` but it wasn't used, so I removed it from the codebase. Now the pg-tests succeed locally for me.


TS 2.13
![image](https://github.com/user-attachments/assets/49347828-f34e-4830-8a7d-585fd1703c8e)


TS 2.14
![image](https://github.com/user-attachments/assets/66d4c1e2-65ce-4be0-8b86-f22ced136b98)
