### PR TITLE
Fixes #206: Exclude dropped chunks from the list of all chunks in the catalog

### DIFF
--- a/internal/containers/relationcache_test.go
+++ b/internal/containers/relationcache_test.go
@@ -64,17 +64,21 @@ func Test_RelationCache_Set_LowerBound_Update(
 	assert.Equal(t, msg3, msg3Back)
 }
 
-func Test_RelationCache_Set_Panic(
+func Test_RelationCache_Empty_Case(
 	t *testing.T,
 ) {
 	cache := NewRelationCache[int32]()
-	cache.Get(0)
+	res, present := cache.Get(0)
+	assert.False(t, present)
+	assert.Equal(t, cache.empty, res)
 }
 
-func Test_RelationCache_Set_Panic_2(
+func Test_RelationCache_Index_Less_Than_LowerBound(
 	t *testing.T,
 ) {
 	cache := NewRelationCache[uint32]()
 	cache.Set(5, 5)
-	cache.Get(1)
+	res, present := cache.Get(1)
+	assert.False(t, present)
+	assert.Equal(t, cache.empty, res)
 }

--- a/internal/systemcatalog/systemcatalog.go
+++ b/internal/systemcatalog/systemcatalog.go
@@ -375,7 +375,9 @@ func (sc *systemCatalog) GetAllChunks() []systemcatalog.SystemEntity {
 	chunkTables := make([]systemcatalog.SystemEntity, 0)
 	for _, chunk := range sc.chunks {
 		if sc.IsHypertableSelectedForReplication(chunk.HypertableId()) {
-			chunkTables = append(chunkTables, chunk)
+			if !chunk.Dropped() {
+				chunkTables = append(chunkTables, chunk)
+			}
 		}
 	}
 	return chunkTables

--- a/tests/publication_test.go
+++ b/tests/publication_test.go
@@ -593,9 +593,15 @@ func (pts *PublicationTestSuite) Test_Dropped_Chunks_Should_Be_Ignored() {
 				return err
 			}
 
-			if _, err := ctx.Exec(context.Background(),
-				"INSERT INTO _timescaledb_catalog.chunk(hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk, creation_time) VALUES (1, '_timescaledb_internal', '_hyper_1_427_chunk', null, true, 0, false, now())",
-			); err != nil {
+			var insertDroppedChunkQuery string
+
+			if ctx.TimescaleVersion().Compare(21200) >= 0 {
+				insertDroppedChunkQuery = "INSERT INTO _timescaledb_catalog.chunk(hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk, creation_time) VALUES (1, '_timescaledb_internal', '_hyper_1_427_chunk', NULL, TRUE, 0, FALSE, NOW())"
+			} else {
+				insertDroppedChunkQuery = "INSERT INTO _timescaledb_catalog.chunk(hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk) VALUES (1, '_timescaledb_internal', '_hyper_1_427_chunk', null, true, 0, false)"
+			}
+
+			if _, err := ctx.Exec(context.Background(), insertDroppedChunkQuery); err != nil {
 				return err
 			}
 

--- a/tests/publication_test.go
+++ b/tests/publication_test.go
@@ -564,6 +564,50 @@ func (pts *PublicationTestSuite) Test_Fixing_Broken_Publications_Without_State_S
 	)
 }
 
+func (pts *PublicationTestSuite) Test_Dropped_Chunks_Should_Be_Ignored() {
+	testSink := testsupport.NewEventCollectorSink()
+	publicationName := lo.RandomString(10, lo.LowerCaseLettersCharset)
+
+	var tableName string
+	pts.RunTest(
+		func(ctx testrunner.Context) error {
+			return nil
+		},
+
+		testrunner.WithSetup(func(ctx testrunner.SetupContext) error {
+			_, tn, err := ctx.CreateHypertable("ts", time.Hour,
+				testsupport.NewColumn("ts", "timestamptz", false, true, nil),
+				testsupport.NewColumn("val", "integer", false, false, nil),
+			)
+			if err != nil {
+				return err
+			}
+			tableName = tn
+
+			if _, err := ctx.Exec(context.Background(),
+				fmt.Sprintf(
+					"INSERT INTO \"%s\" SELECT ts, ROW_NUMBER() OVER (ORDER BY ts) AS val FROM GENERATE_SERIES('2023-03-25 00:00:00'::TIMESTAMPTZ, '2023-03-25 23:59:59'::TIMESTAMPTZ, INTERVAL '1 minute') t(ts)",
+					tableName,
+				),
+			); err != nil {
+				return err
+			}
+
+			if _, err := ctx.Exec(context.Background(),
+				"INSERT INTO _timescaledb_catalog.chunk(hypertable_id, schema_name, table_name, compressed_chunk_id, dropped, status, osm_chunk, creation_time) VALUES (1, '_timescaledb_internal', '_hyper_1_427_chunk', null, true, 0, false, now())",
+			); err != nil {
+				return err
+			}
+
+			ctx.AddSystemConfigConfigurator(testSink.SystemConfigConfigurator)
+			ctx.AddSystemConfigConfigurator(func(config *sysconfig.SystemConfig) {
+				config.PostgreSQL.Publication.Name = publicationName
+			})
+			return nil
+		}),
+	)
+}
+
 func readAllAndPublishedChunks(
 	ctx testrunner.Context, tableName, publicationName string,
 ) (

--- a/testsupport/containers/timescaledb.go
+++ b/testsupport/containers/timescaledb.go
@@ -276,6 +276,17 @@ func SetupTimescaleContainer() (testcontainers.Container, *ConfigProvider, error
 	); err != nil {
 		return nil, nil, err
 	}
+	timescaledbLogger.Verbosef("Grant permissions to default user for timescaledb catalog")
+	if err := exec(
+		fmt.Sprintf("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s TO %s", "_timescaledb_catalog", tsdbUser),
+	); err != nil {
+		return nil, nil, err
+	}
+	if err := exec(
+		fmt.Sprintf("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s TO %s", "_timescaledb_catalog", tsdbUser),
+	); err != nil {
+		return nil, nil, err
+	}
 	timescaledbLogger.Verbosef("Drop existing publication")
 
 	// Create initial publication function


### PR DESCRIPTION
Fixes #206 , builds of #207 

In one my env, I have a hypertable that I want to stream. But it seems to have a permanent dropped chunk entry.

I have added test that simulates it and fails with the same error as the one I experience.

It would also be great if you could cut a release after this :)