### PR TITLE
Align default example config "postgresql.transaction.window.maxsize"

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -10,7 +10,7 @@ postgresql.password = '...'
 #postgresql.snapshot.initial = 'always'
 #postgresql.transaction.window.enabled = true
 #postgresql.transaction.window.timeout = 60
-#postgresql.transaction.window.maxsize = 100000
+#postgresql.transaction.window.maxsize = 10000
 
 statestorage.type = 'file'
 statestorage.file.path = '/tmp/statestorage.dat'

--- a/config.example.yml
+++ b/config.example.yml
@@ -16,7 +16,7 @@ postgresql:
 #    window:
 #      enabled: true
 #      timeout: 60
-#      maxSize: 100000
+#      maxSize: 10000
 
   tables:
     excludes:


### PR DESCRIPTION
README + actual config default has 10k, while the default configs have 100k listed. This fixes that discrepancy.