### PR TITLE
Fix shutdown on database gone

### DIFF
--- a/cmd/timescaledb-event-streamer/main.go
+++ b/cmd/timescaledb-event-streamer/main.go
@@ -175,7 +175,7 @@ func start(
 		done.Signal()
 	}()
 
-	if err := streamer.Start(); err != nil {
+	if err := streamer.Start(signals); err != nil {
 		if err2 := streamer.Stop(); err2 != nil {
 			fmt.Fprintf(log, "Error during early shutdown: %v\n", err2)
 		}

--- a/internal/containers/unboundedchannel.go
+++ b/internal/containers/unboundedchannel.go
@@ -91,6 +91,9 @@ func (uc *UnboundedChannel[T]) ReceiveChannel() <-chan T {
 }
 
 func (uc *UnboundedChannel[T]) Close() {
+	if uc.closed.Load() {
+		return
+	}
 	uc.closed.Store(true)
 	close(uc.in)
 }

--- a/internal/replication/replicationchannel/replicationchannel.go
+++ b/internal/replication/replicationchannel/replicationchannel.go
@@ -32,7 +32,9 @@ import (
 	"github.com/noctarius/timescaledb-event-streamer/spi/sidechannel"
 	"github.com/noctarius/timescaledb-event-streamer/spi/systemcatalog"
 	"github.com/noctarius/timescaledb-event-streamer/spi/task"
+	"os"
 	"sync/atomic"
+	"syscall"
 )
 
 // ReplicationChannel represents the database connection and handler loop
@@ -85,6 +87,7 @@ func (rc *ReplicationChannel) StopReplicationChannel() error {
 // and starts the logical replication handler loop.
 func (rc *ReplicationChannel) StartReplicationChannel(
 	initialTables []systemcatalog.SystemEntity,
+	signalChannel chan<- os.Signal,
 ) error {
 
 	handler, err := newReplicationHandler(rc.replicationContext, rc.typeManager, rc.taskManager, rc.statsReporter)
@@ -181,7 +184,7 @@ func (rc *ReplicationChannel) StartReplicationChannel(
 			if err != nil {
 				rc.logger.Fatalf("Issue handling WAL stream: %s", err)
 			}
-			rc.shutdownAwaiter.SignalShutdown()
+			signalChannel <- syscall.SIGINT
 		}()
 
 		stopReplication = func() {
@@ -249,12 +252,12 @@ func (rc *ReplicationChannel) StartReplicationChannel(
 	}
 
 	go func() {
-		// Mark the current replication channel as shutting down
-		rc.shutdownRequested.Store(true)
-
 		if err := rc.shutdownAwaiter.AwaitShutdown(); err != nil {
 			rc.logger.Errorf("shutdown failed: %+v", err)
 		}
+
+		// Mark the current replication channel as shutting down
+		rc.shutdownRequested.Store(true)
 
 		// Stop potentially started replication before going on
 		stopReplication()

--- a/internal/replication/replicationchannel/replicationhandler.go
+++ b/internal/replication/replicationchannel/replicationhandler.go
@@ -104,6 +104,9 @@ func newReplicationHandler(
 }
 
 func (rh *replicationHandler) stopReplicationHandler() error {
+	if rh.loopDead.Load() {
+		return nil
+	}
 	rh.logger.Println("Starting to shutdown")
 	rh.shutdownAwaiter.SignalShutdown()
 	if rh.loopDead.Load() {
@@ -126,6 +129,7 @@ func (rh *replicationHandler) startReplicationHandler(
 		case <-rh.shutdownAwaiter.AwaitShutdownChan():
 			runtime.UnlockOSThread()
 			rh.shutdownAwaiter.SignalDone()
+			rh.loopDead.Store(true)
 			return nil
 		default:
 		}

--- a/internal/replication/replicator.go
+++ b/internal/replication/replicator.go
@@ -42,6 +42,7 @@ import (
 	"github.com/noctarius/timescaledb-event-streamer/spi/wiring"
 	"github.com/samber/lo"
 	"github.com/urfave/cli"
+	"os"
 	"slices"
 )
 
@@ -74,7 +75,10 @@ func NewReplicator(
 }
 
 // StartReplication initiates the actual replication process
-func (r *Replicator) StartReplication() *cli.ExitError {
+func (r *Replicator) StartReplication(
+	signalChannel chan<- os.Signal,
+) *cli.ExitError {
+
 	r.shutdownTasks = nil
 	container, err := wiring.NewContainer(
 		StaticModule,
@@ -103,6 +107,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 		return erroring.AdaptError(err, 0)
 	}
 	r.shutdownTasks = append(r.shutdownTasks, func() error {
+		r.logger.Infof("Shutting down statistics service")
 		return statsService.Stop()
 	})
 
@@ -113,6 +118,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 	}
 	taskManager.StartDispatcher()
 	r.shutdownTasks = append(r.shutdownTasks, func() error {
+		r.logger.Infof("Shutting down internal dispatching")
 		return taskManager.StopDispatcher()
 	})
 
@@ -125,6 +131,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 		return erroring.AdaptErrorWithMessage(err, "failed to start replication context", 18)
 	}
 	r.shutdownTasks = append(r.shutdownTasks, func() error {
+		r.logger.Infof("Shutting down replication context")
 		return replicationContext.StopReplicationContext()
 	})
 
@@ -138,6 +145,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 		return erroring.AdaptErrorWithMessage(err, "failed to start event emitter", 24)
 	}
 	r.shutdownTasks = append(r.shutdownTasks, func() error {
+		r.logger.Infof("Shutting down event emitter")
 		return eventEmitter.Stop()
 	})
 
@@ -148,6 +156,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 	}
 	snapshotter.StartSnapshotter()
 	r.shutdownTasks = append(r.shutdownTasks, func() error {
+		r.logger.Infof("Shutting down snapshotter")
 		snapshotter.StopSnapshotter()
 		return nil
 	})
@@ -174,6 +183,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 		return erroring.AdaptError(err, 1)
 	}
 	r.shutdownTasks = append(r.shutdownTasks, func() error {
+		r.logger.Infof("Shutting down state storage manager")
 		state, err1 := encodeKnownTables(systemCatalog.GetAllChunks())
 		if err1 == nil {
 			stateStorageManager.SetEncodedState(esPreviouslyKnownChunks, state)
@@ -214,7 +224,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 	if err := container.Service(&replicationChannel); err != nil {
 		return erroring.AdaptError(err, 1)
 	}
-	if err := replicationChannel.StartReplicationChannel(initialTables); err != nil {
+	if err := replicationChannel.StartReplicationChannel(initialTables, signalChannel); err != nil {
 		if errors.Is(err, sidechannel.ErrNoRestartPointInReplicationSlot) {
 			return erroring.AdaptErrorWithMessage(err,
 				"No restart LSN available in replication slot. Cannot resume, replicated data would have gaps.",
@@ -224,6 +234,7 @@ func (r *Replicator) StartReplication() *cli.ExitError {
 		return erroring.AdaptError(err, 16)
 	}
 	r.shutdownTasks = append(r.shutdownTasks, func() error {
+		r.logger.Infof("Shutting down replication channel")
 		return replicationChannel.StopReplicationChannel()
 	})
 

--- a/internal/streamer.go
+++ b/internal/streamer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/noctarius/timescaledb-event-streamer/spi/plugins"
 	"github.com/samber/lo"
 	"github.com/urfave/cli"
+	"os"
 
 	// Register built-in naming strategies
 	_ "github.com/noctarius/timescaledb-event-streamer/spi/namingstrategy"
@@ -98,8 +99,11 @@ func NewStreamer(
 	}, nil
 }
 
-func (s *Streamer) Start() *cli.ExitError {
-	return s.replicator.StartReplication()
+func (s *Streamer) Start(
+	signalChannel chan<- os.Signal,
+) *cli.ExitError {
+
+	return s.replicator.StartReplication(signalChannel)
 }
 
 func (s *Streamer) Stop() *cli.ExitError {

--- a/testsupport/testrunner/runner.go
+++ b/testsupport/testrunner/runner.go
@@ -34,6 +34,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
+	"os"
 	"time"
 )
 
@@ -209,7 +210,8 @@ func (t *testContext) ResumeReplicator() error {
 	if t.streamerRunning {
 		return nil
 	}
-	if err := t.streamer.Start(); err != nil {
+	c := make(chan os.Signal, 1)
+	if err := t.streamer.Start(c); err != nil {
 		if err2 := t.streamer.Stop(); err2 != nil {
 			t.logger.Errorf("Error during early shutdown: %v\n", err2)
 		}


### PR DESCRIPTION
This PR fixes a shutdown issue when the database restarts. The issue occurred due to main.go waiting for the signal handler to finish which was never called. The PR changes the StartReplication logic to block until the internal services are shutdown. That way the main.go doesn't require the additional waiter but just waits for the replicator to return.